### PR TITLE
Add the ability to change the HTTP method used

### DIFF
--- a/src/Bridge/TestCaseTrait.php
+++ b/src/Bridge/TestCaseTrait.php
@@ -13,6 +13,8 @@ use KunicMarko\GraphQLTest\Operation\QueryInterface;
 trait TestCaseTrait
 {
     protected static $endpoint = '/graphql';
+    
+    protected static $method = 'POST';
 
     /**
      * @var array
@@ -22,7 +24,7 @@ trait TestCaseTrait
     public function query(QueryInterface $query, array $files = [], array $headers = [], array $cookies = [])
     {
         return $this->call(
-            'POST',
+            static::$method,
             static::$endpoint,
             ['query' => $query()],
             $cookies,
@@ -34,7 +36,7 @@ trait TestCaseTrait
     public function mutation(MutationInterface $mutation, array $files = [], array $headers = [], array $cookies = [])
     {
         return $this->call(
-            'POST',
+            static::$method,
             static::$endpoint,
             ['query' => $mutation()],
             $cookies,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch because its the main branch used to create releases.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added the ability to change the HTTP method used to call the GraphQL endpoint.

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## Subject

In some implementations, the GraphQL endpoint can only be used with a GET request. This PR allows you to change that with a static property on the `TestCaseTrait` trait. Similar to how you can change the graphql endpoint.